### PR TITLE
Booking confirmation UI - question regarding using && as an IF

### DIFF
--- a/js/wizard/steps/booking-confirmation-step/booking-confirmation-step.js
+++ b/js/wizard/steps/booking-confirmation-step/booking-confirmation-step.js
@@ -38,6 +38,9 @@ export const bookingConfirmationStep = (props) => {
 
    //I had to make displaying this message dependant on an if, because I'd get error
    //due to trying to call .get() on undefined.
+   //    If I have a variable that can be either `present` (object, basic type, etc.
+   //    but not a null) or an `undefined`, what can I do to mitigate the errors
+   //    occurring due to it being an undefined?
    if (props.formData)
       firstMessage.textContent = `Thank you for signing up, Commander ${props.formData.get(
          'name',


### PR DESCRIPTION
I had a code that looked like this: 

```
props.formData && firstMessage.textContent = `Thank you for signing up, Commander ${props.formData.get('name')}!`;
```
But I had to re-write it as this: 

```
   if (props.formData)
      firstMessage.textContent = `Thank you for signing up, Commander ${props.formData.get('name')}!`;
```

The first one would receive an error due to trying to call .get() on an undefined. `props.formData` can either be a null, an undefined, or a FormData object. Why using `&&` as an IF doesn't work if the left side argument is undefined?